### PR TITLE
fix: update deprecated GitHub Actions in CI/CD pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: 8
 
@@ -23,7 +23,7 @@ jobs:
         run: pnpm build
 
       - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v1.0.8
+        uses: actions/upload-pages-artifact@v3
         with:
           path: dist
 
@@ -46,4 +46,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Updated GitHub Actions to latest stable versions:
- pnpm/action-setup@v2 → v4
- actions/upload-pages-artifact@v1.0.8 → v3
- actions/deploy-pages@v2 → v4

🤖 Generated with [Claude Code](https://claude.ai/code)